### PR TITLE
v1.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.0.12
+- Add setGlobalData operation with unit tests and metadata
+- property values can now also resolve to global data. I.e. the value 'globaldata.foo' will be resolved from the globals.
 ## 1.0.11
 - Extra check for controller instance serialization
   

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.11",
+  "version": "1.0.12",
   "license": "MIT",
   "main": "dist/index.js",
   "homepage": "https://rolandzwaga.github.io/eligius/",

--- a/src/operation/add-globals-to-operation.ts
+++ b/src/operation/add-globals-to-operation.ts
@@ -1,4 +1,4 @@
-import { getGlobals } from './helper/get-globals';
+import { getGlobals } from './helper/globals';
 import { TOperation } from './types';
 
 export interface IAddGlobalsToOperationData {
@@ -15,6 +15,7 @@ export interface IAddGlobalsToOperationData {
 export const addGlobalsToOperation: TOperation<IAddGlobalsToOperationData> =
   function (operationData: IAddGlobalsToOperationData) {
     const { globalProperties } = operationData;
+
     const globalValues = globalProperties.reduce(
       (prev: Record<string, any>, current: string) => {
         prev[current] = getGlobals(current);
@@ -23,5 +24,6 @@ export const addGlobalsToOperation: TOperation<IAddGlobalsToOperationData> =
       {}
     );
     delete (operationData as any).globalProperties;
+
     return Object.assign(operationData, globalValues);
   };

--- a/src/operation/helper/extract-operation-data-argument-values.ts
+++ b/src/operation/helper/extract-operation-data-argument-values.ts
@@ -1,4 +1,5 @@
 import { getNestedValue } from './get-nested-value';
+import { getGlobals } from './globals';
 
 export function extractOperationDataArgumentValues(
   sourceObject: any,
@@ -12,5 +13,15 @@ export function extractOperationDataArgumentValues(
     propNames.shift();
     return getNestedValue(propNames, sourceObject);
   }
+
+  if (
+    typeof argumentValue === 'string' &&
+    argumentValue.toLowerCase().startsWith('globaldata.')
+  ) {
+    const propNames = argumentValue.split('.');
+    propNames.shift();
+    return getNestedValue(propNames, getGlobals());
+  }
+
   return argumentValue;
 }

--- a/src/operation/helper/get-globals.ts
+++ b/src/operation/helper/get-globals.ts
@@ -1,9 +1,0 @@
-import { deepCopy } from './deep-copy';
-const cache: Record<string, any> = {};
-
-function _getGlobals(cache: any, name?: string): Record<string, any> | any {
-  const value = name ? cache[name] : cache;
-  return value && value !== cache ? deepCopy(value) : value;
-}
-
-export const getGlobals: (name?: string) => any = _getGlobals.bind(null, cache);

--- a/src/operation/helper/globals.ts
+++ b/src/operation/helper/globals.ts
@@ -1,0 +1,31 @@
+import { deepCopy } from './deep-copy';
+const cache: Record<string, any> = {};
+
+function _getGlobals(
+  cache: Record<string, any>,
+  name?: string
+): Record<string, any> | any {
+  const value = name ? cache[name] : cache;
+  return value && value !== cache ? deepCopy(value) : value;
+}
+
+function _setGlobals(
+  cache: Record<string, any>,
+  newValues: Record<string, any>
+): void {
+  Object.entries(newValues).forEach(([name, value]) => (cache[name] = value));
+  console.log('cache', cache);
+}
+
+function _clearGlobals(cache: Record<string, any>): void {
+  const keys = Object.keys(cache);
+  keys.forEach((key) => delete cache[key]);
+}
+
+export const getGlobals: (name?: string) => Record<string, any> | any =
+  _getGlobals.bind(null, cache);
+
+export const setGlobals: (newValues: Record<string, any>) => void =
+  _setGlobals.bind(null, cache);
+
+export const clearGlobals: () => void = _clearGlobals.bind(null, cache);

--- a/src/operation/helper/set-global.ts
+++ b/src/operation/helper/set-global.ts
@@ -1,4 +1,4 @@
-import { getGlobals } from './get-globals';
+import { getGlobals } from './globals';
 
 export function setGlobal(name: string, value: any) {
   const cache = getGlobals();

--- a/src/operation/index.ts
+++ b/src/operation/index.ts
@@ -30,6 +30,7 @@ export { resizeAction } from './resize-action';
 export { selectElement } from './select-element';
 export { setElementAttributes } from './set-element-attributes';
 export { setElementContent } from './set-element-content';
+export { setGlobalData } from './set-global-data';
 export { setOperationData } from './set-operation-data';
 export { setStyle } from './set-style';
 export { startAction } from './start-action';
@@ -38,4 +39,3 @@ export { toggleClass } from './toggle-class';
 export { toggleElement } from './toggle-element';
 export * from './types';
 export { wait } from './wait';
-

--- a/src/operation/metadata/index.ts
+++ b/src/operation/metadata/index.ts
@@ -30,6 +30,7 @@ export { default as resizeAction } from './resize-action';
 export { default as selectElement } from './select-element';
 export { default as setElementAttributes } from './set-element-attributes';
 export { default as setElementContent } from './set-element-content';
+export { default as setGlobalData } from './set-global-data';
 export { default as setOperationData } from './set-operation-data';
 export { default as setStyle } from './set-style';
 export { default as startAction } from './start-action';
@@ -37,4 +38,3 @@ export { default as startLoop } from './start-loop';
 export { default as toggleClass } from './toggle-class';
 export { default as toggleElement } from './toggle-element';
 export { default as wait } from './wait';
-

--- a/src/operation/metadata/set-global-data.ts
+++ b/src/operation/metadata/set-global-data.ts
@@ -1,0 +1,16 @@
+import { ISetGlobalDataOperationData } from '../set-global-data';
+import { IOperationMetadata } from './types';
+
+function setGlobalData(): IOperationMetadata<ISetGlobalDataOperationData> {
+  return {
+    description:
+      'Copies the specified values from the operationData to the global data',
+    properties: {
+      properties: {
+        type: 'ParameterType:array',
+        required: true,
+      },
+    },
+  };
+}
+export default setGlobalData;

--- a/src/operation/set-global-data.ts
+++ b/src/operation/set-global-data.ts
@@ -1,0 +1,29 @@
+import { setGlobals } from './helper/globals';
+import { TOperation } from './types';
+
+export interface ISetGlobalDataOperationData {
+  properties: string[];
+}
+
+/**
+ * This operation copies the specified values from the operationData to the global data.
+ *
+ * @param operationData
+ * @returns
+ */
+export const setGlobalData: TOperation<ISetGlobalDataOperationData> = function (
+  operationData: ISetGlobalDataOperationData
+) {
+  const { properties } = operationData;
+  const newGlobals = Object.fromEntries(
+    Object.entries(operationData).filter(([name, _value]) =>
+      properties.includes(name)
+    )
+  );
+
+  setGlobals(newGlobals);
+
+  delete (operationData as any).properties;
+
+  return operationData;
+};

--- a/src/test/unit/operation/helper/globals.spec.ts
+++ b/src/test/unit/operation/helper/globals.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { suite } from 'uvu';
-import { getGlobals } from '../../../../operation/helper/get-globals';
+import { getGlobals, setGlobals } from '../../../../operation/helper/globals';
 
 const GetGlobalsSuite = suite('getGlobals');
 
@@ -15,6 +15,17 @@ GetGlobalsSuite('should get the global by name', () => {
   cache['test'] = value;
   cache = getGlobals('test');
   expect(cache).to.equal(value);
+});
+
+const SetGlobalsSuite = suite('setGlobals');
+
+SetGlobalsSuite('should set the given globals', () => {
+  setGlobals({ foo: 'bar', bar: 'foo' });
+
+  const cache = getGlobals();
+
+  expect(cache['foo']).to.equal('bar');
+  expect(cache['bar']).to.equal('foo');
 });
 
 GetGlobalsSuite.run();

--- a/src/test/unit/operation/helper/resolve-property-values.spec.ts
+++ b/src/test/unit/operation/helper/resolve-property-values.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { suite } from 'uvu';
 import { resolvePropertyValues } from '../../../../operation/helper/resolve-property-values';
+import { setGlobal } from '../../../../operation/helper/set-global';
 
 const ResolvePropertyValuesSuite = suite('resolvePropertyValues');
 
@@ -45,5 +46,27 @@ ResolvePropertyValuesSuite(
     expect(resolved.resolvedItem).to.equal('test');
   }
 );
+
+ResolvePropertyValuesSuite(
+  'should resolve the given property values on the global data',
+  () => {
+    // given
+    const operationData = {
+      test1: 'test1',
+      test2: 100,
+      test3: true,
+      currentItem: { title: 'test' },
+      resolvedItem: 'globaldata.globalTitle',
+    };
+    setGlobal('globalTitle', 'global title');
+
+    // test
+    const resolved = resolvePropertyValues(operationData, operationData);
+
+    // expect
+    expect(resolved.resolvedItem).to.equal('global title');
+  }
+);
+
 
 ResolvePropertyValuesSuite.run();

--- a/src/test/unit/operation/helper/set-global.spec.ts
+++ b/src/test/unit/operation/helper/set-global.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { suite } from 'uvu';
-import { getGlobals } from '../../../../operation/helper/get-globals';
+import { getGlobals } from '../../../../operation/helper/globals';
 import { setGlobal } from '../../../../operation/helper/set-global';
 
 const SetGlobalSuite = suite('setGlobal');

--- a/src/test/unit/operation/set-global-data.spec.ts
+++ b/src/test/unit/operation/set-global-data.spec.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import { suite } from 'uvu';
+import { clearGlobals, getGlobals } from '../../../operation/helper/globals';
+import {
+  ISetGlobalDataOperationData,
+  setGlobalData,
+} from '../../../operation/set-global-data';
+import { applyOperation } from '../../../util/apply-operation';
+
+const SetGlobalDataSuite = suite('setGlobalData');
+
+SetGlobalDataSuite.before(() => {
+  clearGlobals();
+});
+
+SetGlobalDataSuite('should set the specified values on the global data', () => {
+  // given
+  const operationData = {
+    properties: ['foo', 'bar'],
+    foo: 'bar',
+    bar: 'foo',
+    test: false,
+  };
+
+  // test
+  const result = applyOperation<ISetGlobalDataOperationData>(
+    setGlobalData,
+    operationData
+  );
+  const globals = getGlobals();
+
+  // expect
+  expect(result).to.eql({ foo: 'bar', bar: 'foo', test: false });
+  expect(globals).to.eql({ foo: 'bar', bar: 'foo' });
+});
+
+SetGlobalDataSuite.run();


### PR DESCRIPTION
- Add setGlobalData operation with unit tests and metadata
- property values can now also resolve to global data. I.e. the value 'globaldata.foo' will be resolved from the globals.