### PR TITLE
Add ConfigurationFactory extension methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.0.16
+- Add static `extend` and `extendMultiple` methods to ConfigurationFactory
+- ActionCreatorFactory.ActionCreator now correctly returns an EndableActionCreator
+- Correctly initialize TimelineProviderSettings in the editor
+- Narrow typing in add-controller-to-element
+
 ## 1.0.15
 - Export configuration factory API
 
@@ -14,7 +20,7 @@
 
 ## 1.0.12
 - Add setGlobalData operation with unit tests and metadata
-- property values can now also resolve to global data. I.e. the value 'globaldata.foo' will be resolved from the globals.
+- property values can now also resolve to global data. I.e. the value `globaldata.foo` will be resolved from the globals.
 ## 1.0.11
 - Extra check for controller instance serialization
   
@@ -28,7 +34,7 @@
 - Add getQueryParams operation
 - Remove propertyName operationData properties from several operations, this needlessly complicated a lot of functionality.
 
-## 1.0.81
+## 1.0.8.1
 - Add null check in prepareValueForSerialization
 
 ## 1.0.8
@@ -37,7 +43,7 @@
 - Add agent listeners for devtools playcontrol events
 - Add destroy method to LanguageManager implmentation
   
-## 1.0.71
+## 1.0.7.1
 
 - Fix postMessage serializations
 ## 1.0.7

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.15",
+  "version": "1.0.16",
   "license": "MIT",
   "main": "dist/index.js",
   "homepage": "https://rolandzwaga.github.io/eligius/",

--- a/src/configuration/api/action-creator-factory.ts
+++ b/src/configuration/api/action-creator-factory.ts
@@ -13,7 +13,7 @@ import { ConfigurationFactory } from './configuration-factory';
 export class ActionCreatorFactory {
   constructor(private readonly configurationfactory: ConfigurationFactory) {}
 
-  createAction(name: string): ActionCreator {
+  createAction(name: string): EndableActionCreator {
     const creator = new EndableActionCreator(name, this);
     this.configurationfactory.addAction(creator.actionConfig);
     return creator;

--- a/src/configuration/api/configuration-factory.ts
+++ b/src/configuration/api/configuration-factory.ts
@@ -92,7 +92,9 @@ export class ConfigurationFactory {
       this.configuration,
       'availableLanguages'
     );
-    const existing = languages.find(lang => lang.languageCode === languageCode);
+    const existing = languages.find(
+      (lang) => lang.languageCode === languageCode
+    );
 
     if (existing) {
       throw new Error(`Language code '${languageCode}' already exists`);
@@ -194,7 +196,7 @@ export class ConfigurationFactory {
   }
 
   getTimeline(uri: string) {
-    return this.configuration.timelines.find(t => t.uri === uri);
+    return this.configuration.timelines.find((t) => t.uri === uri);
   }
 
   removeTimeline(uri: string) {
@@ -209,7 +211,7 @@ export class ConfigurationFactory {
   }
 
   _initializeLabel(id: string, labels: ILanguageLabel[]) {
-    let label = labels.find(l => l.id === id);
+    let label = labels.find((l) => l.id === id);
     if (!label) {
       labels.push({
         id: id,
@@ -222,7 +224,7 @@ export class ConfigurationFactory {
 
   _getLabelTranslation(labelTranslations: ILabel[], languageCode: string) {
     let translation = labelTranslations.find(
-      l => l.languageCode === languageCode
+      (l) => l.languageCode === languageCode
     );
     if (!translation) {
       translation = {
@@ -247,16 +249,16 @@ export class ConfigurationFactory {
   }
 
   editAction(id: string) {
-    const actionConfig = this.configuration.actions.find(a => a.id === id);
+    const actionConfig = this.configuration.actions.find((a) => a.id === id);
     if (actionConfig) {
-      return new ActionEditor(actionConfig, this);
+      return new EndableActionEditor(actionConfig, this);
     }
     throw new Error(`Action not found for id ${id}`);
   }
 
   editEventAction(id: string) {
     const actionConfig = this.configuration.eventActions?.find(
-      a => a.id === id
+      (a) => a.id === id
     );
     if (actionConfig) {
       return new ActionEditor(actionConfig, this);
@@ -265,7 +267,9 @@ export class ConfigurationFactory {
   }
 
   editInitAction(id: string) {
-    const actionConfig = this.configuration.initActions.find(a => a.id === id);
+    const actionConfig = this.configuration.initActions.find(
+      (a) => a.id === id
+    );
     if (actionConfig) {
       return new EndableActionEditor(actionConfig, this);
     }
@@ -277,7 +281,7 @@ export class ConfigurationFactory {
     if (!timeline) {
       throw new Error(`Timeline not found for id ${id}`);
     }
-    const actionConfig = timeline.timelineActions.find(a => a.id === id);
+    const actionConfig = timeline.timelineActions.find((a) => a.id === id);
     if (actionConfig) {
       return new TimelineActionEditor(actionConfig, this);
     }

--- a/src/configuration/api/timeline-provider-settings-editor.ts
+++ b/src/configuration/api/timeline-provider-settings-editor.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid';
 import * as timelineProviders from '../../timelineproviders';
 import { TimelineTypes } from '../../types';
 import { ITimelineProviderSettings, TTimelineProviderSettings } from '../types';
@@ -15,10 +16,10 @@ export class TimelineProvidersSettingsEditor {
         `Settings for a '${timelineType}' provider already exist`
       );
     }
-    const settings = {
-      id: '',
-      poster: '',
-      selector: '',
+    const settings: ITimelineProviderSettings = {
+      id: uuidv4(),
+      poster: undefined,
+      selector: undefined,
       systemName: '',
       vendor: '',
     };

--- a/src/operation/add-controller-to-element.ts
+++ b/src/operation/add-controller-to-element.ts
@@ -1,12 +1,14 @@
 import { IController } from '../controllers/types';
 import { attachControllerToElement } from './helper/attach-controller-to-element';
 import { internalResolve } from './helper/internal-resolve';
-import { TOperation } from './types';
+import { IOperationContext, TOperation, TOperationData } from './types';
 
-export interface IAddControllerToElementOperationData {
+export type IAddControllerToElementOperationData<
+  T extends TOperationData = TOperationData
+> = {
   selectedElement: JQuery;
-  controllerInstance: IController<any>;
-}
+  controllerInstance: IController<T>;
+} & T;
 
 /**
  * This operation adds the specified controller instance to the specified selected element.
@@ -15,7 +17,10 @@ export interface IAddControllerToElementOperationData {
  * @returns
  */
 export const addControllerToElement: TOperation<IAddControllerToElementOperationData> =
-  function (operationData: IAddControllerToElementOperationData) {
+  function <T extends TOperationData = TOperationData>(
+    this: IOperationContext,
+    operationData: IAddControllerToElementOperationData<T>
+  ) {
     const { selectedElement, controllerInstance } = operationData;
 
     attachControllerToElement(selectedElement, controllerInstance);
@@ -26,7 +31,7 @@ export const addControllerToElement: TOperation<IAddControllerToElementOperation
 
     if (promise) {
       return new Promise((resolve, reject) => {
-        promise.then((newOperationData: any) => {
+        promise.then((newOperationData: TOperationData) => {
           internalResolve(resolve, operationData, newOperationData);
         }, reject);
       });


### PR DESCRIPTION
- Add static `extend` and `extendMultiple` methods to ConfigurationFactory
- ActionCreatorFactory.ActionCreator now correctly returns an EndableActionCreator
- Correctly initialize TimelineProviderSettings in the editor
- Narrow typing in add-controller-to-element