### PR TITLE
fix(operation): resolve $scope chains up the parent scope chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eligius",
   "author": "Roland Zwaga <rbzwaga@gmail.com>",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "homepage": "https://rolandzwaga.github.io/eligius/",
   "bugs": {

--- a/src/operation/helper/resolve-external-property-chain.ts
+++ b/src/operation/helper/resolve-external-property-chain.ts
@@ -35,11 +35,43 @@ export function resolveExternalPropertyChain(
       case '$globaldata':
         return getPropertyChainValue(propNames, getGlobals());
       case '$scope':
-        return getPropertyChainValue(propNames, operationScope);
+        return getScopeChainValue(propNames, operationScope);
     }
   }
 
   return propertyChainOrRegularObject;
+}
+
+/**
+ * Resolves a `$scope` property chain, walking up the parent scope chain.
+ *
+ * `forEach` and `when` execute in a child scope created by `Action._pushScope`,
+ * which proxies only a few fields from its parent — notably **not** `variables`.
+ * So a variable set with `setVariable` before (or outside) a loop/conditional
+ * lives on an ancestor scope, not the child scope the operation runs in.
+ *
+ * To make those readable, we resolve the chain against the nearest scope (the
+ * current one or an ancestor) that actually declares the chain's head property.
+ * This gives natural lexical shadowing — an inner declaration of the same name
+ * wins over an outer one — and leaves write semantics untouched (`setVariable`
+ * still writes to whichever scope it runs in).
+ *
+ * If no scope in the chain declares the head property, resolution falls back to
+ * the original scope so the standard "cannot be resolved" error is produced.
+ */
+function getScopeChainValue(
+  propertyChain: string[],
+  operationScope: IOperationScope
+) {
+  const head = propertyChain[0];
+  let scope: IOperationScope | undefined = operationScope;
+  while (scope) {
+    if (head in scope) {
+      return getPropertyChainValue(propertyChain, scope);
+    }
+    scope = scope.parent;
+  }
+  return getPropertyChainValue(propertyChain, operationScope);
 }
 
 export function isExternalProperty(

--- a/src/test/integration/for-each-loop.spec.ts
+++ b/src/test/integration/for-each-loop.spec.ts
@@ -13,6 +13,7 @@ import {
 import {
   endWhen,
   type IOperationScope,
+  setVariable,
   type TOperationData,
   when,
 } from '@operation/index.ts';
@@ -519,5 +520,50 @@ describe<ForEachLoopContext>('Start and end a for each loop', () => {
     expect(loopCounter).toBe(1);
     expect(operationData.newCollection).toBeUndefined();
     expect(operationData.test).toBe(true);
+  });
+
+  test<ForEachLoopContext>('should loop over a collection held in a scope variable', async context => {
+    const {action} = context;
+
+    // setVariable writes to the base scope; forEach runs in a pushed child scope
+    // and reads `$scope.variables.items` back — which only works once $scope
+    // resolution walks up to the parent scope that actually holds `variables`.
+    const setItems: IResolvedOperation = {
+      id: 'set',
+      systemName: 'setVariable',
+      operationData: {name: 'items', value: ['a', 'b', 'c']},
+      instance: setVariable,
+    };
+    const loop: IResolvedOperation = {
+      id: 'loop',
+      systemName: forEachSystemName,
+      operationData: {
+        collection: '$scope.variables.items',
+      } as IForEachOperationData,
+      instance: forEach,
+    };
+    const collect: IResolvedOperation = {
+      id: 'collect',
+      systemName: 'collect',
+      operationData: {},
+      instance: function (this: IOperationScope, op: any) {
+        if (!op.seen) op.seen = [];
+        op.seen.push(this.currentItem);
+        return op;
+      },
+    };
+    const end: IResolvedOperation = {
+      id: 'end',
+      systemName: endForEachSystemName,
+      operationData: {},
+      instance: endForEach,
+    };
+    action.startOperations.push(setItems, loop, collect, end);
+
+    // test
+    const operationData = (await action.start()) as TOperationData;
+
+    // expect: the loop iterated over the variable's collection
+    expect(operationData.seen).toEqual(['a', 'b', 'c']);
   });
 });

--- a/src/test/unit/operation/helper/resolve-external-property-chain.spec.ts
+++ b/src/test/unit/operation/helper/resolve-external-property-chain.spec.ts
@@ -66,6 +66,76 @@ describe('resolveExternalPropertyChain', () => {
     // expect
     expect(value).toBe(100);
   });
+  test('should resolve a $scope variable declared on a parent scope', () => {
+    // given: a child scope (as forEach/when create) whose parent holds the variable
+    const parent = {
+      variables: {items: ['a', 'b', 'c']},
+    } as unknown as IOperationScope;
+    const child = {parent} as unknown as IOperationScope;
+
+    // test
+    const value = resolveExternalPropertyChain(
+      {},
+      child,
+      '$scope.variables.items' as ExternalProperty
+    );
+
+    // expect
+    expect(value).toEqual(['a', 'b', 'c']);
+  });
+  test('should resolve through multiple parent scopes', () => {
+    // given
+    const grandparent = {
+      variables: {greeting: 'hi'},
+    } as unknown as IOperationScope;
+    const parent = {parent: grandparent} as unknown as IOperationScope;
+    const child = {parent} as unknown as IOperationScope;
+
+    // test
+    const value = resolveExternalPropertyChain(
+      {},
+      child,
+      '$scope.variables.greeting' as ExternalProperty
+    );
+
+    // expect
+    expect(value).toBe('hi');
+  });
+  test('should let an inner scope shadow an outer scope variable', () => {
+    // given: same variable name on both scopes — the nearest one wins
+    const parent = {
+      variables: {x: 'outer'},
+    } as unknown as IOperationScope;
+    const child = {
+      variables: {x: 'inner'},
+      parent,
+    } as unknown as IOperationScope;
+
+    // test
+    const value = resolveExternalPropertyChain(
+      {},
+      child,
+      '$scope.variables.x' as ExternalProperty
+    );
+
+    // expect
+    expect(value).toBe('inner');
+  });
+  test('should throw when a $scope variable exists on no scope in the chain', () => {
+    // given
+    const child = {
+      parent: {} as IOperationScope,
+    } as unknown as IOperationScope;
+
+    // test / expect
+    expect(() =>
+      resolveExternalPropertyChain(
+        {},
+        child,
+        '$scope.variables.missing' as ExternalProperty
+      )
+    ).toThrow(/cannot be resolved/);
+  });
   test('should return null if argumentValue is null', () => {
     // given
     const operationData = {};


### PR DESCRIPTION
forEach and when execute in a child scope created by Action._pushScope, which proxies only currentIndex/eventbus/operations from its parent — not `variables`. So a variable set with setVariable before (or outside) a loop/conditional lives on an ancestor scope, and `$scope.variables.x` resolved against the child scope threw "Property chain 'variables.x' cannot be resolved" — breaking any scope variable used as a forEach collection or read inside a when/forEach body.

resolveExternalPropertyChain now resolves a $scope chain against the nearest scope (current or ancestor) that declares the chain's head property, walking `.parent`. This gives natural lexical shadowing (inner declarations win) and leaves write semantics untouched (setVariable still writes to its own scope). If no scope declares the head, it falls back to the original scope so the standard "cannot be resolved" error is still produced.

Tests: parent-scope resolution, multi-level walk, inner-shadows-outer, and not-found-throws (unit); a setVariable→forEach-over-$scope.variables loop (integration).