### PR TITLE
feat(metadata): add jquery-free `eligius/metadata` subpath export

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,21 @@ It is encouraged to use this API to build specialized DSL's for specific present
 
 Also, there is the [Eligian](https://github.com/rolandzwaga/eligian) project that aims to become an actual programming language for the Eligius runtime.
 
+## Metadata import (`eligius/metadata`)
+
+Tooling that only needs to *inspect* Eligius's operation, controller and event **metadata** — code generators, DSL compilers, completion providers, documentation tools — can import it from the dedicated `eligius/metadata` entry point:
+
+```javascript
+import { metadata, ctrlmetadata, eventmetadata } from 'eligius/metadata';
+
+const operationNames = Object.keys(metadata);      // 'addClass', 'selectElement', ...
+const { description, properties } = metadata.addClass();
+```
+
+This entry is bundled separately and contains **only metadata** — it does not pull in the engine runtime (jQuery, lottie-web, video.js). As a result it can be imported from a plain Node process **without a DOM**, unlike the main `eligius` entry, which evaluates the browser runtime (jQuery) on import and therefore requires a `window`.
+
+Rule of thumb: use `eligius/metadata` for build-time and server-side tooling; use the main `eligius` entry to actually run the engine.
+
 ## Source documentation
 
 [Check out this link for the full type docs](https://rolandzwaga.github.io/eligius/)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eligius",
   "author": "Roland Zwaga <rbzwaga@gmail.com>",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "license": "MIT",
   "homepage": "https://rolandzwaga.github.io/eligius/",
   "bugs": {
@@ -14,6 +14,7 @@
   "type": "module",
   "exports": {
     ".": "./dist/index.mjs",
+    "./metadata": "./dist/metadata.mjs",
     "./package.json": "./package.json"
   },
   "typesVersions": {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,0 +1,21 @@
+/**
+ * Metadata-only entry point (`eligius/metadata`).
+ *
+ * This re-exports ONLY the operation / controller / event metadata namespaces
+ * and their types. The metadata is pure data — each descriptor file imports the
+ * operation's data interface as a `type` (erased at build), never the operation
+ * implementation — so this entry is bundled into its own chunk that does NOT
+ * import jquery / lottie-web / video.js.
+ *
+ * Importing from the main `eligius` entry evaluates the full engine bundle,
+ * which pulls in jquery@4 — and jquery@4 throws `jQuery requires a window with a
+ * document` the instant it is evaluated in a DOM-less Node context. Tooling that
+ * only needs metadata (code generators, completion providers, DSL compilers)
+ * should import from `eligius/metadata` so it works in plain Node without a DOM.
+ */
+export * as ctrlmetadata from '@controllers/metadata/index.ts';
+export * from '@controllers/metadata/types.ts';
+export * as eventmetadata from '@eventbus/events/metadata/index.ts';
+export * from '@eventbus/events/metadata/types.ts';
+export * as metadata from '@operation/metadata/index.ts';
+export * from '@operation/metadata/types.ts';

--- a/src/tools/code-generator/ctrls-metadata-generator.ts
+++ b/src/tools/code-generator/ctrls-metadata-generator.ts
@@ -197,21 +197,28 @@ const createSourceFile =
       ? toOperationDataType(outputSourceFile)(operationData)
       : [undefined, undefined, []];
 
+    // Top-level `import type { … }` so the type import is fully elided. Inline
+    // `import { type … }` under verbatimModuleSyntax leaves a side-effect
+    // `import "./controller"`, pulling the controller implementation (and jquery)
+    // into the metadata-only bundle (`eligius/metadata`).
     if (importName) {
-      outputSourceFile
-        .addImportDeclaration({moduleSpecifier: `@controllers/${fileName}.ts`})
-        .addNamedImport({name: importName, isTypeOnly: true});
-    }
-    outputSourceFile
-      .addImportDeclaration({moduleSpecifier: '@controllers/metadata/types.ts'})
-      .addNamedImport({name: 'IControllerMetadata', isTypeOnly: true});
-    imports.forEach(imp => {
-      const importDeclaration = outputSourceFile.addImportDeclaration({
-        moduleSpecifier: imp.importPath,
+      outputSourceFile.addImportDeclaration({
+        moduleSpecifier: `@controllers/${fileName}.ts`,
+        isTypeOnly: true,
+        namedImports: [importName],
       });
-      imp.types.forEach(type =>
-        importDeclaration.addNamedImport({name: type, isTypeOnly: true})
-      );
+    }
+    outputSourceFile.addImportDeclaration({
+      moduleSpecifier: '@controllers/metadata/types.ts',
+      isTypeOnly: true,
+      namedImports: ['IControllerMetadata'],
+    });
+    imports.forEach(imp => {
+      outputSourceFile.addImportDeclaration({
+        moduleSpecifier: imp.importPath,
+        isTypeOnly: true,
+        namedImports: imp.types,
+      });
     });
 
     outputSourceFile.addFunction({

--- a/src/tools/code-generator/events-metadata-generator.ts
+++ b/src/tools/code-generator/events-metadata-generator.ts
@@ -78,19 +78,22 @@ const createSourceFile = (
     {overwrite: true}
   );
 
-  // Import the event interface
-  outputSourceFile
-    .addImportDeclaration({
-      moduleSpecifier: `${EVENTBUS_EVENTS_ALIAS}/${fileName}.ts`,
-    })
-    .addNamedImport({name: eventName, isTypeOnly: true});
+  // Import the event interface. Top-level `import type { … }` (not inline
+  // `import { type … }`) so it's fully elided — under verbatimModuleSyntax an
+  // inline type specifier leaves a side-effect `import "./event"` that would pull
+  // implementation code into the metadata-only bundle (`eligius/metadata`).
+  outputSourceFile.addImportDeclaration({
+    moduleSpecifier: `${EVENTBUS_EVENTS_ALIAS}/${fileName}.ts`,
+    isTypeOnly: true,
+    namedImports: [eventName],
+  });
 
   // Import IEventMetadata
-  outputSourceFile
-    .addImportDeclaration({
-      moduleSpecifier: `${EVENTBUS_EVENTS_ALIAS}/metadata/types.ts`,
-    })
-    .addNamedImport({name: 'IEventMetadata', isTypeOnly: true});
+  outputSourceFile.addImportDeclaration({
+    moduleSpecifier: `${EVENTBUS_EVENTS_ALIAS}/metadata/types.ts`,
+    isTypeOnly: true,
+    namedImports: ['IEventMetadata'],
+  });
 
   // Get args tuple from the interface property type node (not the type object)
   const argsProperty = interfaceDecl.getProperty('args')!;
@@ -218,11 +221,11 @@ const toTypesFile = (
   eventData.forEach(({iface, sourceFile}) => {
     const eventName = iface.getName();
     const fileName = sourceFile.getBaseName().replace(/\.ts$/, '');
-    outputSourceFile
-      .addImportDeclaration({
-        moduleSpecifier: `${EVENTBUS_EVENTS_ALIAS}/${fileName}.ts`,
-      })
-      .addNamedImport({name: eventName, isTypeOnly: true});
+    outputSourceFile.addImportDeclaration({
+      moduleSpecifier: `${EVENTBUS_EVENTS_ALIAS}/${fileName}.ts`,
+      isTypeOnly: true,
+      namedImports: [eventName],
+    });
   });
 
   // Create AllEvents union type

--- a/src/tools/code-generator/metadata-generator.ts
+++ b/src/tools/code-generator/metadata-generator.ts
@@ -208,21 +208,29 @@ const createSourceFile =
       ? toOperationDataType(outputSourceFile)(operationData)
       : [undefined, undefined, []];
 
+    // Use declaration-level `import type { … }` (not inline `import { type … }`).
+    // Under verbatimModuleSyntax, an inline type specifier still emits a
+    // side-effect `import "./mod"`, which drags the operation implementation
+    // (and thus jquery) into the metadata-only bundle (`eligius/metadata`). A
+    // top-level type-only import is fully elided.
     if (importName) {
-      outputSourceFile
-        .addImportDeclaration({moduleSpecifier: `@operation/${fileName}.ts`})
-        .addNamedImport({name: importName, isTypeOnly: true});
-    }
-    outputSourceFile
-      .addImportDeclaration({moduleSpecifier: '@operation/metadata/types.ts'})
-      .addNamedImport({name: 'IOperationMetadata', isTypeOnly: true});
-    imports.forEach(imp => {
-      const importDeclaration = outputSourceFile.addImportDeclaration({
-        moduleSpecifier: imp.importPath,
+      outputSourceFile.addImportDeclaration({
+        moduleSpecifier: `@operation/${fileName}.ts`,
+        isTypeOnly: true,
+        namedImports: [importName],
       });
-      imp.types.forEach(type =>
-        importDeclaration.addNamedImport({name: type, isTypeOnly: true})
-      );
+    }
+    outputSourceFile.addImportDeclaration({
+      moduleSpecifier: '@operation/metadata/types.ts',
+      isTypeOnly: true,
+      namedImports: ['IOperationMetadata'],
+    });
+    imports.forEach(imp => {
+      outputSourceFile.addImportDeclaration({
+        moduleSpecifier: imp.importPath,
+        isTypeOnly: true,
+        namedImports: imp.types,
+      });
     });
 
     outputSourceFile.addFunction({

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,38 +4,50 @@ import {defineConfig} from 'tsdown';
 
 const srcDir = resolve(import.meta.dirname, 'src');
 
-export default defineConfig({
-  entry: ['./src/index.ts'],
+const aliasPlugin = alias({
+  entries: [
+    {find: /^@\/(.*)/, replacement: `${srcDir}/$1`},
+    {find: /^@action\/(.*)/, replacement: `${srcDir}/action/$1`},
+    {
+      find: /^@configuration\/(.*)/,
+      replacement: `${srcDir}/configuration/$1`,
+    },
+    {find: /^@controllers\/(.*)/, replacement: `${srcDir}/controllers/$1`},
+    {find: /^@diagnostics\/(.*)/, replacement: `${srcDir}/diagnostics/$1`},
+    {find: /^@eventbus\/(.*)/, replacement: `${srcDir}/eventbus/$1`},
+    {find: /^@importer\/(.*)/, replacement: `${srcDir}/importer/$1`},
+    {find: /^@operation\/(.*)/, replacement: `${srcDir}/operation/$1`},
+    {
+      find: /^@timelineproviders\/(.*)/,
+      replacement: `${srcDir}/timelineproviders/$1`,
+    },
+    {find: /^@util\/(.*)/, replacement: `${srcDir}/util/$1`},
+    {find: /^@test\/(.*)/, replacement: `${srcDir}/test/$1`},
+  ],
+}) as any;
+
+const base = {
   external: ['lottie-web', 'jquery', 'video.js'],
-  format: ['esm'],
-  platform: 'node',
+  format: ['esm'] as const,
+  platform: 'node' as const,
   sourcemap: true,
   minify: false,
   target: 'es2022',
-  exports: true,
-  clean: true,
   outDir: './dist',
-  plugins: [
-    alias({
-      entries: [
-        {find: /^@\/(.*)/, replacement: `${srcDir}/$1`},
-        {find: /^@action\/(.*)/, replacement: `${srcDir}/action/$1`},
-        {
-          find: /^@configuration\/(.*)/,
-          replacement: `${srcDir}/configuration/$1`,
-        },
-        {find: /^@controllers\/(.*)/, replacement: `${srcDir}/controllers/$1`},
-        {find: /^@diagnostics\/(.*)/, replacement: `${srcDir}/diagnostics/$1`},
-        {find: /^@eventbus\/(.*)/, replacement: `${srcDir}/eventbus/$1`},
-        {find: /^@importer\/(.*)/, replacement: `${srcDir}/importer/$1`},
-        {find: /^@operation\/(.*)/, replacement: `${srcDir}/operation/$1`},
-        {
-          find: /^@timelineproviders\/(.*)/,
-          replacement: `${srcDir}/timelineproviders/$1`,
-        },
-        {find: /^@util\/(.*)/, replacement: `${srcDir}/util/$1`},
-        {find: /^@test\/(.*)/, replacement: `${srcDir}/test/$1`},
-      ],
-    }) as any,
-  ],
-});
+  plugins: [aliasPlugin],
+};
+
+// Two INDEPENDENT builds (the `build` npm script `rimraf`s dist first, so neither
+// needs `clean`). They are intentionally separate so the metadata entry gets its
+// OWN bundle and can never share a rolldown chunk with the engine: a single
+// multi-entry build co-locates the metadata namespaces with the operation /
+// controller implementations (which import jquery@4), which would defeat the
+// whole point of `eligius/metadata`. The metadata graph only `import { type … }`s
+// the operation-data interfaces (erased via verbatimModuleSyntax), so its
+// standalone bundle is free of jquery / lottie-web / video.js and imports cleanly
+// in a DOM-less Node context. The package.json `exports` map is maintained by
+// hand (no `exports: true`) so the two builds don't fight over it.
+export default defineConfig([
+  {...base, entry: ['./src/index.ts']},
+  {...base, entry: ['./src/metadata.ts']},
+]);


### PR DESCRIPTION
The single bundle entry evaluates jquery@4 at import, which throws in any DOM-less Node context. Tooling that only needs metadata (code generators, DSL compilers, completion providers) had no way to read it without a DOM.

- add `src/metadata.ts` entry re-exporting the metadata namespaces + types
- build it as an independent bundle (separate tsdown config) so it never shares a rolldown chunk with the engine implementations
- generators now emit top-level `import type {}` (not inline `import { type }`): under verbatimModuleSyntax the inline form leaves a side-effect import that pulled implementations (and jquery) into the metadata bundle
- add `"./metadata"` to package.json exports; bump to 2.3.0

dist/metadata.mjs is free of jquery/lottie-web/video.js and imports cleanly in plain Node. Main entry unchanged (still re-exports metadata). 1091 tests pass, typecheck + biome clean.