### PR TITLE
feat(operation): resolve bracket array-indices in property chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eligius",
   "author": "Roland Zwaga <rbzwaga@gmail.com>",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "homepage": "https://rolandzwaga.github.io/eligius/",
   "bugs": {

--- a/src/operation/helper/get-property-chain-value.ts
+++ b/src/operation/helper/get-property-chain-value.ts
@@ -23,14 +23,26 @@ export function getPropertyChainValue(
 ) {
   let suffix = null;
 
-  const result = propertyChain.reduce((currentInstance, prop, index) => {
+  // Expand bracket array-indices into their own chain segments so bracket and dot
+  // notation are equivalent: `eventArgs[0]` resolves like `eventArgs.0`, and
+  // `items[2].label` like `items.2.label`. Arrays index by string key, so reading
+  // `['eventArgs', '0']` returns element 0. Segments without brackets are untouched,
+  // so existing dotted chains (and the `+suffix` concat below) behave exactly as before.
+  const chain = propertyChain.flatMap(segment =>
+    segment
+      .replace(/\[(\d+)\]/g, '.$1')
+      .split('.')
+      .filter(part => part.length > 0)
+  );
+
+  const result = chain.reduce((currentInstance, prop, index) => {
     if (!currentInstance) {
       throw new Error(
-        `Property chain '${propertyChain.join('.')}' cannot be resolved.`
+        `Property chain '${chain.join('.')}' cannot be resolved.`
       );
     }
 
-    if (index === propertyChain.length - 1) {
+    if (index === chain.length - 1) {
       const parts = prop.split('+');
       if (parts.length > 1) {
         prop = parts[0];

--- a/src/test/unit/operation/helper/get-property-chain-value.spec.ts
+++ b/src/test/unit/operation/helper/get-property-chain-value.spec.ts
@@ -40,4 +40,44 @@ describe('getNestedValue', () => {
     // expect
     expect(value).toBe('100px');
   });
+  test('should resolve a bracket array-index segment', () => {
+    // given
+    const operationData = {eventArgs: ['#first', '#second']};
+
+    // test / expect
+    expect(getPropertyChainValue(['eventArgs[0]'], operationData)).toBe(
+      '#first'
+    );
+    expect(getPropertyChainValue(['eventArgs[1]'], operationData)).toBe(
+      '#second'
+    );
+  });
+  test('should resolve bracket indices mixed with dotted properties', () => {
+    // given
+    const operationData = {items: [{label: 'a'}, {label: 'b'}]};
+
+    // test
+    const value = getPropertyChainValue(['items[1]', 'label'], operationData);
+
+    // expect
+    expect(value).toBe('b');
+  });
+  test('should treat bracket notation as equivalent to dot notation', () => {
+    // given
+    const operationData = {rows: [['x', 'y']]};
+
+    // test / expect — nested indices
+    expect(getPropertyChainValue(['rows[0][1]'], operationData)).toBe('y');
+    expect(getPropertyChainValue(['rows', '0', '1'], operationData)).toBe('y');
+  });
+  test('should still suffix a bracket-indexed terminal value', () => {
+    // given
+    const operationData = {sizes: [42]};
+
+    // test
+    const value = getPropertyChainValue(['sizes[0]+px'], operationData);
+
+    // expect
+    expect(value).toBe('42px');
+  });
 });

--- a/src/test/unit/operation/helper/resolve-external-property-chain.spec.ts
+++ b/src/test/unit/operation/helper/resolve-external-property-chain.spec.ts
@@ -49,6 +49,27 @@ describe('resolveExternalPropertyChain', () => {
     // expect
     expect(value).toBe('bar');
   });
+  test('should resolve a bracket array-index in an operationdata chain', () => {
+    // given: the shape an `on event` handler sees — args land on eventArgs[]
+    const operationData = {eventArgs: ['#first', '#second']};
+    const operationScope = {} as IOperationScope;
+
+    // test / expect — bracket notation resolves the array element
+    expect(
+      resolveExternalPropertyChain(
+        operationData,
+        operationScope,
+        '$operationdata.eventArgs[0]' as ExternalProperty
+      )
+    ).toBe('#first');
+    expect(
+      resolveExternalPropertyChain(
+        operationData,
+        operationScope,
+        '$operationdata.eventArgs[1]' as ExternalProperty
+      )
+    ).toBe('#second');
+  });
   test('should resolve the scope argument values', () => {
     // given
     const operationData = {


### PR DESCRIPTION
getPropertyChainValue now normalizes bracket indices into chain segments (`eventArgs[0]` -> `eventArgs.0`), so bracket and dot notation are equivalent for every property-chain consumer (resolveExternalPropertyChain, the $scope walk, resolvePropertyChain, setData). Arrays index by string key, so `['eventArgs','0']` reads element 0; segments without brackets are untouched, so existing dotted chains and the `+suffix` concat behave exactly as before.

This lets `$operationdata.eventArgs[0]` (and `$globaldata.items[2].label`, etc.) resolve — previously the bracket stayed glued to the segment and the literal key `"eventArgs[0]"` was looked up, yielding undefined.

Tests: bracket index, bracket+dot mix, nested `[0][1]`, bracket+`+px` suffix, and the `$operationdata.eventArgs[0]` case at the resolver API. Bump to 2.3.1.